### PR TITLE
Add snapcraft to enable building snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: moviescore
+version: '0.0'
+summary: A cli tool to get movie ratings and reviews directly to your terminal!
+description: |
+  A Cli utility written in go language to get movie ratings , Trailer Links
+  and reviews from the internet. Right into your Terminal!
+
+grade: stable
+confinement: strict
+
+apps:
+  moviescore:
+    command: MovieScore
+    plugs: [network]
+
+parts:
+  moviescore:
+    plugin: go
+    source: https://github.com/popey/MovieScore.git
+    source-type: git
+    go-importpath: github.com/popey/MovieScore


### PR DESCRIPTION
Adds support for building snaps via snapcraft - see http://snapcraft.io/ for more information. Hooking this up means that builds of master can be pushed to the store and make latest builds of MovieScore are immediately available to millions of users. I've already tested this and pushed MovieScore to the 'edge' channel in the store so it can be installed on a supported (amd64 only, I didn't build i386 or armhf yet) distro via:-

snap install moviescore --edge

This will add the moviescore command to your system.

To test the build used to make the snap, on an up to date 16.04 machine

apt install snapcraft

git clone http://github.com/popey/MovieScore
git checkout add-snapcraft
cd MovieScore
snapcraft

This will build a snap which can be installed via:-

snap install moviescore_0.0_amd64.snap --dangerous

(the --dangerous is required as it's an unsigned package being side-loaded, rather than a signed one from hte store).

Test the application as expected.

Would be great to get this merged, and then hook up the automated builds to land in the store directly, as per http://snapcraft.io/docs/build-snaps/ci-integration. Happy to help through that process. We also have an automated system at http://build.snapcraft.io/ which could be used to auto-build and push to the store (once we transfer the registration of the moviescore name to you from me).

